### PR TITLE
added form_tag_with_body

### DIFF
--- a/lib/cell/haml.rb
+++ b/lib/cell/haml.rb
@@ -10,7 +10,7 @@ module Cell
 
     def set_output_buffer_with_haml(new_buffer)
       if is_haml?
-        if Haml::Util.rails_xss_safe? && new_buffer.is_a?(ActiveSupport::SafeBuffer)
+        if ::Haml::Util.rails_xss_safe? && new_buffer.is_a?(ActiveSupport::SafeBuffer)
           new_buffer = String.new(new_buffer)
         end
         haml_buffer.buffer = new_buffer
@@ -59,6 +59,10 @@ module Cell
     # From FormTagHelper. why do they escape every possible string? why?
     def form_tag_in_block(html_options, &block)
       content = capture(&block)
+      "#{form_tag_html(html_options)}" << content << "</form>"
+    end
+
+    def form_tag_with_body(html_options, content)
       "#{form_tag_html(html_options)}" << content << "</form>"
     end
 


### PR DESCRIPTION
I've notice that you override form_tag_html (now it returns String). That is why there were missing methods in  ```actionview (4.2.0) lib/action_view/helpers/form_tag_helper.rb:868:in `form_tag_with_body'```. I've overrided form_tag_with_body to fix this.