### PR TITLE
update readme installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,9 @@ Add this line to your application's Gemfile:
 
 ```ruby
 gem 'cells-haml'
-gem "haml", github: "haml/haml", ref: "7c7c169"
 ```
 
-This gem currently only works properly with Haml 4.1, which is not yet released.
-
+This gem currently only works properly with Haml 4.1.0.beta.1 or newer.
 
 ## HTML Escaping
 


### PR DESCRIPTION
`cells-haml` has a dependency to [`haml >= 4.1.0.beta.1`](https://github.com/trailblazer/cells-haml/blob/cefceab2843e3994d6629c348a50d50b46bcafbe/cells-haml.gemspec#L21), this version is [released](https://rubygems.org/gems/haml/versions/4.1.0.beta.1), so we don't need this github ref