### PR TITLE
Depend on stable version of cells.

### DIFF
--- a/cells-haml.gemspec
+++ b/cells-haml.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'cells', '~> 4.0.0.beta6'
+  spec.add_dependency 'cells', '~> 4.0.1'
   spec.add_dependency 'haml', '>= 4.1.0.beta.1'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Cells is currently at version `4.0.4`. There is no reason to be depending on an unstable release anymore.