### PR TITLE
Require 'cells' as a dependency

### DIFF
--- a/lib/cells-haml.rb
+++ b/lib/cells-haml.rb
@@ -1,1 +1,2 @@
+require 'cells'
 require 'cell/haml'


### PR DESCRIPTION
Currently, the 'cells' gem is a dependency, but is not explicitly required.
Implicitly relying on 'cells' to be required by the consuming application causes
an 'uninitialized constant' error when requiring this gem in isolation.

This closes apotonick/cells#374.